### PR TITLE
More octopus plurals

### DIFF
--- a/src/noun/list_exceptions.ts
+++ b/src/noun/list_exceptions.ts
@@ -218,7 +218,7 @@ const singular2plural =<NounConversionObject>{
 	"nucleus": 					["nuclei"],
 	"oaf": 						["oafs"], 
 	"oasis": 					["oases"],
-	"octopus": 					["octopi","octopuses"],
+	"octopus": 					["octopi","octopuses","octopodes"],
 	"opus": 					["opera","operas"],
 	"ornis": 					["ornithes"],
 	"ovum": 					["ova"],


### PR DESCRIPTION
Added 'octopodes' as a plural of octopus. While rarely used it is arguably more correct than octopi: https://english.stackexchange.com/questions/270/what-is-the-correct-plural-of-octopus