### PR TITLE
Fix typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ instance.superlative(); // biggest
 new Inflectors("rallied").conjugate("VBP"); // rally
 new Inflectors("fly").conjugate("VBD"); // flew
 new Inflectors("throw").conjugate("VBN"); // thrown
-new Inflectors("rally").conjugate("VBS"); // rallies
+new Inflectors("rally").conjugate("VBZ"); // rallies
 new Inflectors("die").conjugate("VBG"); // dying
 
 // or you can use the aliases

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ new Inflectors("rallied").conjugate("VBP"); // rally
 new Inflectors("fly").conjugate("VBD"); // flew
 new Inflectors("throw").conjugate("VBN"); // thrown
 new Inflectors("rally").conjugate("VBS"); // rallies
-new Inflectors("die").conjugate("VBP"); // dying
+new Inflectors("die").conjugate("VBG"); // dying
 
 // or you can use the aliases
 new Inflectors("rallied").toPresent(); // rally


### PR DESCRIPTION
The "VBP"  example was repeated twice. Looks like the second is supposed to be a gerund example, "VBG"